### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A sophisticated Model Context Protocol (MCP) server that provides comprehensive multi-topic search capabilities powered by the Tavily API. This agent enables intelligent information gathering across business, news, finance, and politics domains with a focus on high-quality, reliable sources.
 
+<a href="https://glama.ai/mcp/servers/p0w4whs3l4"><img width="380" height="200" src="https://glama.ai/mcp/servers/p0w4whs3l4/badge" alt="Tavily Search Agent MCP server" /></a>
+
 ## Features
 
 - 🔍 **Multi-Topic Search**: Specialized search configurations for business, news, finance, and politics


### PR DESCRIPTION
This PR adds a badge for the [Tavily Search MCP Agent](https://glama.ai/mcp/servers/p0w4whs3l4) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/p0w4whs3l4"><img width="380" height="200" src="https://glama.ai/mcp/servers/p0w4whs3l4/badge" alt="Tavily Search Agent MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.